### PR TITLE
Remove unnecessary spacing in CSV string generation.

### DIFF
--- a/Widgets/TagCollection.cs
+++ b/Widgets/TagCollection.cs
@@ -51,7 +51,7 @@ public class TagCollection
             return;
 
         _latestStringTags = tagList;
-        _latestString = string.Join(", ", tagList);
+        _latestString = string.Join(",", tagList);
     }
 
     /// <summary> 
@@ -141,7 +141,7 @@ public class TagCollection
         }
         CkGui.HelpText(HELP_TEXT, tooltipCol);
 
-        updatedCsvString = string.Join(", ", _latestStringTags);
+        updatedCsvString = string.Join(",", _latestStringTags);
         return change;
     }
 

--- a/Widgets/TagCollection.cs
+++ b/Widgets/TagCollection.cs
@@ -218,7 +218,7 @@ public class TagCollection
         float rightEndOffset = 4 * ImGuiHelpers.GlobalScale;
 
         bool changed = DrawEditorCore(x, rightEndOffset, tooltipCol);
-        updatedCsvString = string.Join(", ", _latestStringTags);
+        updatedCsvString = string.Join(",", _latestStringTags);
         return changed;
     }
 


### PR DESCRIPTION
This was causing issues with parsing the strings inputted as it would add a leading space in all items after the first one.

Note:
Current Tags will only be fixed after either editing them or adding a new tag to the list.